### PR TITLE
Allow HTML error messages

### DIFF
--- a/tollbooth.go
+++ b/tollbooth.go
@@ -141,7 +141,9 @@ func LimitHandler(limiter *config.Limiter, next http.Handler) http.Handler {
 	middle := func(w http.ResponseWriter, r *http.Request) {
 		httpError := LimitByRequest(limiter, r)
 		if httpError != nil {
-			http.Error(w, httpError.Message, httpError.StatusCode)
+			w.Header().Add("Content-Type", "text/html; charset=utf-8")
+			w.Write([]byte(httpError.Message))
+			w.WriteHeader(httpError.StatusCode)
 			return
 		}
 


### PR DESCRIPTION
Hi,

Allowing HTML error messages is a nice feature. I'm using this in [Algernon](https://github.com/xyproto/algernon).

Reject, accept or ask me to make changes to the pull request at will.

Thanks for creating tollbooth!

Best regards,
   Alexander Rødseth