### PR TITLE
Issue #17 Fix - Only 1 token returned after duration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,7 +62,7 @@ type Limiter struct {
 func (l *Limiter) LimitReached(key string) bool {
 	l.Lock()
 	if _, found := l.tokenBuckets[key]; !found {
-		l.tokenBuckets[key] = ratelimit.NewBucket(l.TTL, l.Max)
+		l.tokenBuckets[key] = ratelimit.NewBucketWithQuantum(l.TTL, l.Max, l.Max)
 	}
 
 	_, isSoonerThanMaxWait := l.tokenBuckets[key].TakeMaxDuration(1, 0)


### PR DESCRIPTION
in juju/ratelimit: 
NewBucket "fills at the rate of one token every fillInterval", where in NewBucketWithQuantum "quantum tokens are added every fillInterval."

Since throttling limit is configured per fillInterval, it is expected that upon a new fillInterval the bucket would be full again. Therefore adding Quantum tokens each fillInterval instead of only 1 token each fillInterval is the expected behavior.

Please see Issue#17 for details and steps to reproduce.