### PR TITLE
Update Negroni's import path

### DIFF
--- a/thirdparty/tollbooth_negroni/README.md
+++ b/thirdparty/tollbooth_negroni/README.md
@@ -1,6 +1,6 @@
 ## tollbooth_negroni
 
-[Negroni](https://github.com/codegangsta/negroni) middleware for rate limiting HTTP requests.
+[Negroni](https://github.com/urfave/negroni) middleware for rate limiting HTTP requests.
 
 
 ## Five Minutes Tutorial
@@ -9,7 +9,7 @@
 package main
 
 import (
-    "github.com/codegangsta/negroni"
+    "github.com/urfave/negroni"
     "github.com/didip/tollbooth"
     "github.com/didip/tollbooth/thirdparty/tollbooth_negroni"
     "net/http"

--- a/thirdparty/tollbooth_negroni/tollbooth_negroni.go
+++ b/thirdparty/tollbooth_negroni/tollbooth_negroni.go
@@ -1,7 +1,7 @@
 package tollbooth_negroni
 
 import (
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 	"github.com/didip/tollbooth"
 	"github.com/didip/tollbooth/config"
 	"net/http"


### PR DESCRIPTION
The package Negroni has moved from github.com/codegangsta/negroni to
github.com/urfave/negroni, so we need to update its import paths.

Signed-off-by: Crístian Deives <cristiandeives@gmail.com>