### PR TITLE
Add index to look up correct IP from list of proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ func main() {
     limiter.IPLookups = []string{"RemoteAddr", "X-Forwarded-For", "X-Real-IP"}
 
     // Configure number of steps to take in X-Forwarded-For list.
-    // By default it's 1. Set to 0 to get the proxy IP.
-    // Use -1 to get the start of the list.
-    limiter.XForwardedForIndex = 1
+    // By default it's 0. This checks the first IP from the list.
+    // Set to -1 to get the last or -2 to get the second-to-last.
+    limiter.XForwardedForIndex = 0
 
     // Limit only GET and POST requests.
     limiter.Methods = []string{"GET", "POST"}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ func main() {
     // If your application is behind a proxy, set "X-Forwarded-For" first.
     limiter.IPLookups = []string{"RemoteAddr", "X-Forwarded-For", "X-Real-IP"}
 
+    // Configure number of steps to take in X-Forwarded-For list.
+    // By default it's 1. Set to 0 to get the proxy IP.
+    // Use -1 to get the start of the list.
+    limiter.XForwardedForIndex = 1
+
     // Limit only GET and POST requests.
     limiter.Methods = []string{"GET", "POST"}
 

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ func NewLimiter(max int64, ttl time.Duration) *Limiter {
 	limiter.Message = "You have reached maximum request limit."
 	limiter.StatusCode = 429
 	limiter.IPLookups = []string{"RemoteAddr", "X-Forwarded-For", "X-Real-IP"}
+	limiter.XForwardedForIndex = 1
 
 	limiter.tokenBucketsNoTTL = make(map[string]*rate.Limiter)
 
@@ -62,6 +63,11 @@ type Limiter struct {
 	// Default is "RemoteAddr", "X-Forwarded-For", "X-Real-IP".
 	// You can rearrange the order as you like.
 	IPLookups []string
+
+	// The number of steps to take from the proxy in the X-Forwarded-For list.
+	// Default is 1. Using 0 will give the proxy IP (end of the list).
+	// Using -1 will give the original sender (start of the list).
+	XForwardedForIndex int
 
 	// List of HTTP Methods to limit (GET, POST, PUT, etc.).
 	// Empty means limit all methods.

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ func NewLimiter(max int64, ttl time.Duration) *Limiter {
 	limiter.Message = "You have reached maximum request limit."
 	limiter.StatusCode = 429
 	limiter.IPLookups = []string{"RemoteAddr", "X-Forwarded-For", "X-Real-IP"}
-	limiter.XForwardedForIndex = 1
+	limiter.XForwardedForIndex = 0
 
 	limiter.tokenBucketsNoTTL = make(map[string]*rate.Limiter)
 

--- a/libstring/libstring.go
+++ b/libstring/libstring.go
@@ -25,7 +25,7 @@ func ipAddrFromRemoteAddr(s string) string {
 }
 
 // RemoteIP finds IP Address given http.Request struct.
-func RemoteIP(ipLookups []string, r *http.Request) string {
+func RemoteIP(ipLookups []string, xForwardedForIndex int, r *http.Request) string {
 	realIP := r.Header.Get("X-Real-IP")
 	forwardedFor := r.Header.Get("X-Forwarded-For")
 
@@ -39,7 +39,11 @@ func RemoteIP(ipLookups []string, r *http.Request) string {
 			for i, p := range parts {
 				parts[i] = strings.TrimSpace(p)
 			}
-			return parts[0]
+			if xForwardedForIndex < 0 {
+				return parts[-1-xForwardedForIndex]
+			} else {
+				return parts[len(parts)-1-xForwardedForIndex]
+			}
 		}
 		if lookup == "X-Real-IP" && realIP != "" {
 			return realIP

--- a/libstring/libstring.go
+++ b/libstring/libstring.go
@@ -40,9 +40,9 @@ func RemoteIP(ipLookups []string, xForwardedForIndex int, r *http.Request) strin
 				parts[i] = strings.TrimSpace(p)
 			}
 			if xForwardedForIndex < 0 {
-				return parts[-1-xForwardedForIndex]
+				return parts[len(parts)+xForwardedForIndex]
 			} else {
-				return parts[len(parts)-1-xForwardedForIndex]
+				return parts[xForwardedForIndex]
 			}
 		}
 		if lookup == "X-Real-IP" && realIP != "" {

--- a/libstring/libstring_test.go
+++ b/libstring/libstring_test.go
@@ -29,7 +29,7 @@ func TestRemoteIPDefault(t *testing.T) {
 
 	request.Header.Set("X-Real-IP", ipv6)
 
-	ip := RemoteIP(ipLookups, request)
+	ip := RemoteIP(ipLookups, 1, request)
 	if ip != request.RemoteAddr {
 		t.Errorf("Did not get the right IP. IP: %v", ip)
 	}
@@ -47,15 +47,19 @@ func TestRemoteIPForwardedFor(t *testing.T) {
 		t.Errorf("Unable to create new HTTP request. Error: %v", err)
 	}
 
-	request.Header.Set("X-Forwarded-For", "54.223.11.104")
+	request.Header.Set("X-Forwarded-For", "54.223.11.104,54.223.11.105,54.223.11.106,54.223.11.107,54.223.11.108")
 	request.Header.Set("X-Real-IP", ipv6)
 
-	ip := RemoteIP(ipLookups, request)
-	if ip != "54.223.11.104" {
-		t.Errorf("Did not get the right IP. IP: %v", ip)
-	}
+	ip := RemoteIP(ipLookups, 1, request)
 	if ip == ipv6 {
 		t.Errorf("X-Real-IP should have been skipped. IP: %v", ip)
+	}
+	if ip != "54.223.11.107" {
+		t.Errorf("Did not get the right IP. IP: %v", ip)
+	}
+	ip = RemoteIP(ipLookups, -1, request)
+	if ip != "54.223.11.104" {
+		t.Errorf("Did not get the right IP. IP: %v", ip)
 	}
 }
 
@@ -71,7 +75,7 @@ func TestRemoteIPRealIP(t *testing.T) {
 	request.Header.Set("X-Forwarded-For", "54.223.11.104")
 	request.Header.Set("X-Real-IP", ipv6)
 
-	ip := RemoteIP(ipLookups, request)
+	ip := RemoteIP(ipLookups, 1, request)
 	if ip != ipv6 {
 		t.Errorf("Did not get the right IP. IP: %v", ip)
 	}

--- a/libstring/libstring_test.go
+++ b/libstring/libstring_test.go
@@ -50,15 +50,15 @@ func TestRemoteIPForwardedFor(t *testing.T) {
 	request.Header.Set("X-Forwarded-For", "54.223.11.104,54.223.11.105,54.223.11.106,54.223.11.107,54.223.11.108")
 	request.Header.Set("X-Real-IP", ipv6)
 
-	ip := RemoteIP(ipLookups, 1, request)
+	ip := RemoteIP(ipLookups, 0, request)
 	if ip == ipv6 {
 		t.Errorf("X-Real-IP should have been skipped. IP: %v", ip)
 	}
-	if ip != "54.223.11.107" {
+	if ip != "54.223.11.104" {
 		t.Errorf("Did not get the right IP. IP: %v", ip)
 	}
-	ip = RemoteIP(ipLookups, -1, request)
-	if ip != "54.223.11.104" {
+	ip = RemoteIP(ipLookups, -2, request)
+	if ip != "54.223.11.107" {
 		t.Errorf("Did not get the right IP. IP: %v", ip)
 	}
 }

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -60,7 +60,7 @@ func LimitByRequest(limiter *config.Limiter, r *http.Request) *errors.HTTPError 
 
 // BuildKeys generates a slice of keys to rate-limit by given config and request structs.
 func BuildKeys(limiter *config.Limiter, r *http.Request) [][]string {
-	remoteIP := libstring.RemoteIP(limiter.IPLookups, r)
+	remoteIP := libstring.RemoteIP(limiter.IPLookups, limiter.XForwardedForIndex, r)
 	path := r.URL.Path
 	sliceKeys := make([][]string, 0)
 

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -286,17 +286,17 @@ func TestLimitHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 
+	handler.ServeHTTP(rr, req)
+	//Should not be limited
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
 	go func() {
 		handler.ServeHTTP(rr, req)
-		// Should not be limited
-		if status := rr.Code; status != http.StatusOK {
-			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+		// Should be limited
+		if status := rr.Code; status != http.StatusTooManyRequests {
+			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusTooManyRequests)
 		}
 	}()
-
-	handler.ServeHTTP(rr, req)
-	//Should be limited
-	if status := rr.Code; status != http.StatusTooManyRequests {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusTooManyRequests)
-	}
 }


### PR DESCRIPTION
When a user passes through multiple proxies, the X-Forwarded-For list will contain multiple IP addresses. For example,
[1.1.1.1, 2.2.2.2, 3.3.3.3, 4.4.4.4, 5.5.5.5]
Currently, the first IP address is selected. However, this one can easily be spoofed by adjusting the request headers. It is conventional to not use the last one (5.5.5.5, which is the address of your own proxy) but the one before that (4.4.4.4) which is the one that cannot be spoofed but does give information about the client.

To accomplish this, an extra option `limiter.XForwardedForIndex` has been added. Its default value is 1, which returns `4.4.4.4`, but it can also be set to 0 (returning `5.5.5.5`), -1 (returning `1.1.1.1`) or other numbers. (Negative numbers count from the back.) It is only used when X-Forwarded-For is used.