### PR TITLE
Add an optional rejectFunc, called on a 429

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ func main() {
     // If your application is behind a proxy, set "X-Forwarded-For" first.
     limiter.IPLookups = []string{"RemoteAddr", "X-Forwarded-For", "X-Real-IP"}
 
+    // Add a function to be called when a request is rejected.
+    limiter.RejectFunc = func() { fmt.Println("A request was rejected") }
+ 
     // Limit only GET and POST requests.
     limiter.Methods = []string{"GET", "POST"}
 

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ func NewLimiter(max int64, ttl time.Duration) *Limiter {
 	limiter.Message = "You have reached maximum request limit."
 	limiter.StatusCode = 429
 	limiter.IPLookups = []string{"RemoteAddr", "X-Forwarded-For", "X-Real-IP"}
+	limiter.RejectFunc = nil
 
 	limiter.tokenBucketsNoTTL = make(map[string]*rate.Limiter)
 
@@ -62,6 +63,9 @@ type Limiter struct {
 	// Default is "RemoteAddr", "X-Forwarded-For", "X-Real-IP".
 	// You can rearrange the order as you like.
 	IPLookups []string
+
+	// A function to call when a request is rejected.
+	RejectFunc func()
 
 	// List of HTTP Methods to limit (GET, POST, PUT, etc.).
 	// Empty means limit all methods.

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -169,6 +169,9 @@ func LimitHandler(limiter *config.Limiter, next http.Handler) http.Handler {
 			w.Header().Add("Content-Type", limiter.MessageContentType)
 			w.WriteHeader(httpError.StatusCode)
 			w.Write([]byte(httpError.Message))
+			if limiter.RejectFunc != nil {
+				limiter.RejectFunc()
+			}
 			return
 		}
 


### PR DESCRIPTION
This pull request enables a function
```
limiter.RejectFunc = func() { fmt.Println("A request was rejected!") }
```
which is called whenever a request is rejected. This allows users to add logging/monitoring for when this happens.