### PR TITLE
Execute onLimitReached function before http.WriteHeader

### DIFF
--- a/tollbooth.go
+++ b/tollbooth.go
@@ -160,11 +160,10 @@ func LimitHandler(lmt *limiter.Limiter, next http.Handler) http.Handler {
 	middle := func(w http.ResponseWriter, r *http.Request) {
 		httpError := LimitByRequest(lmt, w, r)
 		if httpError != nil {
+			lmt.ExecOnLimitReached(w, r)
 			w.Header().Add("Content-Type", lmt.GetMessageContentType())
 			w.WriteHeader(httpError.StatusCode)
 			w.Write([]byte(httpError.Message))
-
-			lmt.ExecOnLimitReached(w, r)
 			return
 		}
 


### PR DESCRIPTION
Hi,

I had a use case earlier were I had to set headers on the limiter response, it seems that this is supposed to be made through the OnLimitReached function, which has the signature of an http.HandlerFunc. However, this does not work for this purpose: 
`lmt := limiter.New(nil).SetMax(int64(RateLimitPerMinute)).SetTTL(time.Minute).
		SetIPLookups([]string{"X-Forwarded-For", "RemoteAddr", "X-Real-IP"}).
		SetMethods([]string{"GET", "POST"}).
		SetOnLimitReached(func(w http.ResponseWriter, _ *http.Request) {
			setCorsHeaders(w)
		})
`
Indeed, tollbooth.LimitHandler calls http.WriteHeader before executing the custom function, which makes it impossible to alter the response with additional headers in the custom onLimitReached function. This seems to be an undesired behaviour, which can be easily fixed by reversing the two calls.