### PR TITLE
Remove TTL. Use max as bucket refill rate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,19 @@ func main() {
         "github.com/didip/tollbooth/limiter"
     )
 
-    lmt := tollbooth.NewLimiter(1, time.Second, nil)
+    lmt := tollbooth.NewLimiter(1, nil)
 
     // or create a limiter with expirable token buckets
     // This setting means:
     // create a 1 request/second limiter and
     // every token bucket in it will expire 1 hour after it was initially set.
-    lmt = tollbooth.NewLimiter(1, time.Second, &limiter.ExpirableOptions{DefaultExpirationTTL: time.Hour})
+    lmt = tollbooth.NewLimiter(1, &limiter.ExpirableOptions{DefaultExpirationTTL: time.Hour})
 
     // Configure list of places to look for IP address.
     // By default it's: "RemoteAddr", "X-Forwarded-For", "X-Real-IP"
     // If your application is behind a proxy, set "X-Forwarded-For" first.
     lmt.SetIPLookups([]string{"RemoteAddr", "X-Forwarded-For", "X-Real-IP"})
- 
+
     // Limit only GET and POST requests.
     lmt.SetMethods([]string{"GET", "POST"})
 

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -53,11 +53,8 @@ func New(generalExpirableOptions *ExpirableOptions) *Limiter {
 
 // Limiter is a config struct to limit a particular request handler.
 type Limiter struct {
-	// Maximum number of requests to limit per duration.
+	// Maximum number of requests to limit per second.
 	max int64
-
-	// Duration of rate-limiter.
-	ttl time.Duration
 
 	// HTTP message when limit is reached.
 	message string
@@ -164,22 +161,6 @@ func (l *Limiter) GetMax() int64 {
 	l.RLock()
 	defer l.RUnlock()
 	return l.max
-}
-
-// SetTTL is thread-safe way of setting maximum number of requests to limit per duration.
-func (l *Limiter) SetTTL(ttl time.Duration) *Limiter {
-	l.Lock()
-	l.ttl = ttl
-	l.Unlock()
-
-	return l
-}
-
-// GetTTL is thread-safe way of getting maximum number of requests to limit per duration.
-func (l *Limiter) GetTTL() time.Duration {
-	l.RLock()
-	defer l.RUnlock()
-	return l.ttl
 }
 
 // SetMessage is thread-safe way of setting HTTP message when limit is reached.
@@ -441,7 +422,6 @@ func (l *Limiter) RemoveHeaderEntries(header string, entriesForRemoval []string)
 
 func (l *Limiter) limitReachedWithTokenBucketTTL(key string, tokenBucketTTL time.Duration) bool {
 	lmtMax := l.GetMax()
-	lmtTTL := l.GetTTL()
 
 	l.Lock()
 	defer l.Unlock()
@@ -449,7 +429,7 @@ func (l *Limiter) limitReachedWithTokenBucketTTL(key string, tokenBucketTTL time
 	if _, found := l.tokenBuckets.Get(key); !found {
 		l.tokenBuckets.Set(
 			key,
-			rate.NewLimiter(rate.Every(lmtTTL), int(lmtMax)),
+			rate.NewLimiter(rate.Limit(lmtMax), 1),
 			tokenBucketTTL,
 		)
 	}

--- a/limiter/limiter_benchmark_test.go
+++ b/limiter/limiter_benchmark_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func BenchmarkLimitReached(b *testing.B) {
-	lmt := New(nil).SetMax(1).SetTTL(time.Second)
+	lmt := New(nil).SetMax(1)
 	key := "127.0.0.1|/"
 
 	for i := 0; i < b.N; i++ {
@@ -15,7 +15,7 @@ func BenchmarkLimitReached(b *testing.B) {
 }
 
 func BenchmarkLimitReachedWithExpiringBuckets(b *testing.B) {
-	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Minute, ExpireJobInterval: 30 * time.Second}).SetMax(1).SetTTL(time.Second)
+	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Minute, ExpireJobInterval: 30 * time.Second}).SetMax(1)
 	key := "127.0.0.1|/"
 
 	for i := 0; i < b.N; i++ {

--- a/limiter/limiter_setter_getter_test.go
+++ b/limiter/limiter_setter_getter_test.go
@@ -2,11 +2,10 @@ package limiter
 
 import (
 	"testing"
-	"time"
 )
 
 func TestSetGetMessage(t *testing.T) {
-	lmt := New(nil).SetMax(1).SetTTL(time.Second)
+	lmt := New(nil).SetMax(1)
 
 	// Check default
 	if lmt.GetMessage() != "You have reached maximum request limit." {
@@ -19,7 +18,7 @@ func TestSetGetMessage(t *testing.T) {
 }
 
 func TestSetGetMessageContentType(t *testing.T) {
-	lmt := New(nil).SetMax(1).SetTTL(time.Second)
+	lmt := New(nil).SetMax(1)
 
 	// Check default
 	if lmt.GetMessageContentType() != "text/plain; charset=utf-8" {
@@ -32,7 +31,7 @@ func TestSetGetMessageContentType(t *testing.T) {
 }
 
 func TestSetGetStatusCode(t *testing.T) {
-	lmt := New(nil).SetMax(1).SetTTL(time.Second)
+	lmt := New(nil).SetMax(1)
 
 	// Check default
 	if lmt.GetStatusCode() != 429 {
@@ -45,7 +44,7 @@ func TestSetGetStatusCode(t *testing.T) {
 }
 
 func TestSetGetIPLookups(t *testing.T) {
-	lmt := New(nil).SetMax(1).SetTTL(time.Second)
+	lmt := New(nil).SetMax(1)
 
 	// Check default
 	if len(lmt.GetIPLookups()) != 3 {
@@ -58,7 +57,7 @@ func TestSetGetIPLookups(t *testing.T) {
 }
 
 func TestSetGetMethods(t *testing.T) {
-	lmt := New(nil).SetMax(1).SetTTL(time.Second)
+	lmt := New(nil).SetMax(1)
 
 	// Check default
 	if len(lmt.GetMethods()) != 0 {
@@ -71,7 +70,7 @@ func TestSetGetMethods(t *testing.T) {
 }
 
 func TestSetGetBasicAuthUsers(t *testing.T) {
-	lmt := New(nil).SetMax(1).SetTTL(time.Second)
+	lmt := New(nil).SetMax(1)
 
 	// Check default
 	if len(lmt.GetBasicAuthUsers()) != 0 {
@@ -108,7 +107,7 @@ func TestSetGetBasicAuthUsers(t *testing.T) {
 }
 
 func TestSetGetHeaders(t *testing.T) {
-	lmt := New(nil).SetMax(1).SetTTL(time.Second)
+	lmt := New(nil).SetMax(1)
 
 	// Check default
 	if len(lmt.GetHeaders()) != 0 {

--- a/limiter/limiter_test.go
+++ b/limiter/limiter_test.go
@@ -6,12 +6,9 @@ import (
 )
 
 func TestConstructor(t *testing.T) {
-	lmt := New(nil).SetMax(1).SetTTL(time.Second)
+	lmt := New(nil).SetMax(1)
 	if lmt.GetMax() != 1 {
 		t.Errorf("Max field is incorrect. Value: %v", lmt.GetMax())
-	}
-	if lmt.GetTTL() != time.Second {
-		t.Errorf("TTL field is incorrect. Value: %v", lmt.GetTTL())
 	}
 	if lmt.GetMessage() != "You have reached maximum request limit." {
 		t.Errorf("Message field is incorrect. Value: %v", lmt.GetMessage())
@@ -22,12 +19,9 @@ func TestConstructor(t *testing.T) {
 }
 
 func TestConstructorExpiringBuckets(t *testing.T) {
-	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Second, ExpireJobInterval: 0}).SetMax(1).SetTTL(time.Second)
+	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Second, ExpireJobInterval: 0}).SetMax(1)
 	if lmt.GetMax() != 1 {
 		t.Errorf("Max field is incorrect. Value: %v", lmt.GetMax())
-	}
-	if lmt.GetTTL() != time.Second {
-		t.Errorf("TTL field is incorrect. Value: %v", lmt.GetTTL())
 	}
 	if lmt.GetMessage() != "You have reached maximum request limit." {
 		t.Errorf("Message field is incorrect. Value: %v", lmt.GetMessage())
@@ -38,7 +32,7 @@ func TestConstructorExpiringBuckets(t *testing.T) {
 }
 
 func TestLimitReached(t *testing.T) {
-	lmt := New(nil).SetMax(1).SetTTL(time.Second)
+	lmt := New(nil).SetMax(1)
 	key := "127.0.0.1|/"
 
 	if lmt.LimitReached(key) == true {
@@ -56,7 +50,7 @@ func TestLimitReached(t *testing.T) {
 }
 
 func TestLimitReachedWithCustomTokenBucketTTL(t *testing.T) {
-	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Second, ExpireJobInterval: 0}).SetMax(1).SetTTL(time.Second)
+	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Second, ExpireJobInterval: 0}).SetMax(1)
 	key := "127.0.0.1|/"
 
 	if lmt.LimitReached(key) == true {
@@ -75,7 +69,7 @@ func TestLimitReachedWithCustomTokenBucketTTL(t *testing.T) {
 
 func TestMuchHigherMaxRequests(t *testing.T) {
 	numRequests := 1000
-	lmt := New(nil).SetMax(int64(numRequests)).SetTTL(time.Second)
+	lmt := New(nil).SetMax(int64(numRequests))
 	key := "127.0.0.1|/"
 
 	for i := 0; i < numRequests; i++ {
@@ -92,7 +86,7 @@ func TestMuchHigherMaxRequests(t *testing.T) {
 
 func TestMuchHigherMaxRequestsWithCustomTokenBucketTTL(t *testing.T) {
 	numRequests := 1000
-	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Minute, ExpireJobInterval: time.Minute}).SetMax(int64(numRequests)).SetTTL(time.Second)
+	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Minute, ExpireJobInterval: time.Minute}).SetMax(int64(numRequests))
 	key := "127.0.0.1|/"
 
 	for i := 0; i < numRequests; i++ {

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -15,14 +15,14 @@ import (
 // setResponseHeaders configures X-Rate-Limit-Limit and X-Rate-Limit-Duration
 func setResponseHeaders(lmt *limiter.Limiter, w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("X-Rate-Limit-Limit", strconv.FormatInt(lmt.GetMax(), 10))
-	w.Header().Add("X-Rate-Limit-Duration", lmt.GetTTL().String())
+	w.Header().Add("X-Rate-Limit-Duration", "1")
 	w.Header().Add("X-Rate-Limit-Request-Forwarded-For", r.Header.Get("X-Forwarded-For"))
 	w.Header().Add("X-Rate-Limit-Request-Remote-Addr", r.RemoteAddr)
 }
 
 // NewLimiter is a convenience function to limiter.New.
 func NewLimiter(max int64, ttl time.Duration, tbOptions *limiter.ExpirableOptions) *limiter.Limiter {
-	return limiter.New(tbOptions).SetMax(max).SetTTL(ttl)
+	return limiter.New(tbOptions).SetMax(max)
 }
 
 // LimitByKeys keeps track number of request made by keys separated by pipe.

--- a/tollbooth_benchmark_test.go
+++ b/tollbooth_benchmark_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func BenchmarkLimitByKeys(b *testing.B) {
-	lmt := limiter.New(nil).SetMax(1).SetTTL(time.Second) // Only 1 request per second is allowed.
+	lmt := limiter.New(nil).SetMax(1) // Only 1 request per second is allowed.
 
 	for i := 0; i < b.N; i++ {
 		LimitByKeys(lmt, []string{"127.0.0.1", "/"})
@@ -21,7 +21,7 @@ func BenchmarkLimitByKeys(b *testing.B) {
 func BenchmarkLimitByKeysWithExpiringBuckets(b *testing.B) {
 	lmt := limiter.New(
 		&limiter.ExpirableOptions{DefaultExpirationTTL: time.Minute, ExpireJobInterval: time.Minute},
-	).SetMax(1).SetTTL(time.Second) // Only 1 request per second is allowed.
+	).SetMax(1) // Only 1 request per second is allowed.
 
 	for i := 0; i < b.N; i++ {
 		LimitByKeys(lmt, []string{"127.0.0.1", "/"})
@@ -29,7 +29,7 @@ func BenchmarkLimitByKeysWithExpiringBuckets(b *testing.B) {
 }
 
 func BenchmarkBuildKeys(b *testing.B) {
-	lmt := limiter.New(nil).SetMax(1).SetTTL(time.Second) // Only 1 request per second is allowed.
+	lmt := limiter.New(nil).SetMax(1) // Only 1 request per second is allowed.
 	lmt.SetIPLookups([]string{"X-Real-IP", "RemoteAddr", "X-Forwarded-For"})
 	lmt.SetHeaders(make(map[string][]string))
 	lmt.SetHeader("X-Real-IP", []string{"2601:7:1c82:4097:59a0:a80b:2841:b8c8"})

--- a/tollbooth_bug_report_test.go
+++ b/tollbooth_bug_report_test.go
@@ -4,7 +4,6 @@
 package tollbooth
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,7 +14,7 @@ import (
 
 // See: https://github.com/didip/tollbooth/issues/48
 func Test_Issue48_RequestTerminatedEvenOnLowVolumeOnSameIP(t *testing.T) {
-	lmt := limiter.New(nil).SetMax(20).SetTTL(time.Second)
+	lmt := limiter.New(nil).SetMax(20)
 	lmt.SetMethods([]string{"GET"})
 
 	limitReachedCounter := 0
@@ -30,13 +29,15 @@ func Test_Issue48_RequestTerminatedEvenOnLowVolumeOnSameIP(t *testing.T) {
 	//
 	// Report stated that a constant 2 requests per second over several minutes would cause
 	// a limit of 20/req/sec to start returning 429.
-	timeout := time.After(10 * time.Minute)
+	timeout := time.After(1 * time.Minute)
 	iterations := 0
 	start := time.Now()
+
+Top:
 	for {
 		select {
 		case <-timeout:
-			break
+			break Top
 		case <-time.After(500 * time.Millisecond):
 			req, _ := http.NewRequest("GET", "/doesntmatter", nil)
 			req.RemoteAddr = "127.0.0.1"
@@ -49,45 +50,6 @@ func Test_Issue48_RequestTerminatedEvenOnLowVolumeOnSameIP(t *testing.T) {
 			}
 			iterations++
 		}
-	}
-
-	if limitReachedCounter > 0 {
-		t.Fatalf("We should never reached the limit, the counter should be 0. limitReachedCounter: %v", limitReachedCounter)
-	}
-}
-
-// See: https://github.com/didip/tollbooth/issues/48
-func Test_Issue48_RequestTerminatedEvenOnLowVolumeOnDifferentIPs(t *testing.T) {
-	lmt := limiter.New(nil).SetMax(20).SetTTL(time.Second)
-	lmt.SetMethods([]string{"GET"})
-
-	limitReachedCounter := 0
-	lmt.SetOnLimitReached(func(w http.ResponseWriter, r *http.Request) { limitReachedCounter++ })
-
-	handler := LimitHandler(lmt, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`hello world`))
-	}))
-
-	// Why 11 times?
-	// Because 11 * 2 = 22, and our limit is 20.
-	// If the bug report is as what I understood, then this test is expected to break.
-	tries := 11
-	for i := 0; i < tries; i++ {
-		// Twice per second should not be limited
-		for j := 0; j < 2; j++ {
-			req, _ := http.NewRequest("GET", "/doesntmatter", nil)
-			req.RemoteAddr = fmt.Sprintf("127.0.0.%v", i)
-
-			rr := httptest.NewRecorder()
-			handler.ServeHTTP(rr, req)
-
-			//Should not be limited
-			if status := rr.Code; status != http.StatusOK {
-				t.Fatalf("Should be able to handle 20 reqs/second. HTTP status: %v. Expected HTTP status: %v", status, http.StatusOK)
-			}
-		}
-
-		time.Sleep(time.Second)
 	}
 
 	if limitReachedCounter > 0 {

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -266,7 +266,7 @@ func TestRequestMethodCustomHeadersAndBasicAuthUsersBuildKeys(t *testing.T) {
 }
 
 func TestLimitHandler(t *testing.T) {
-	lmt := limiter.New(nil).SetMax(1).SetTTL(time.Second)
+	lmt := limiter.New(nil).SetMax(1)
 	lmt.SetIPLookups([]string{"X-Real-IP", "RemoteAddr", "X-Forwarded-For"})
 	lmt.SetMethods([]string{"POST"})
 


### PR DESCRIPTION
Fix #48

This change removes the TTL, as it doesn't necessarily make sense for use with the token bucket. The token bucket refills at a rate of `r` tokens per second, which is defined by the `max` value in tollbooth. As such, it makes sense that tollbooth only supports "number of requests per `second`", rather than allowing the user to define a duration for those requests.

This is a breaking change and existing code will need to be updated.

Obviously you might want to go with a different solution @didip, but this one made sense to me and my tests now pass.