### PR TITLE
add burst parameter to limiter with getters and setters

### DIFF
--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -178,7 +178,7 @@ func (l *Limiter) SetBurst(burst int) *Limiter {
 // GetBurst is thread-safe way of setting maximum burst size.
 func (l *Limiter) GetBurst() int {
 	l.RLock()
-	l.RUnlock()
+	defer l.RUnlock()
 
 	return l.burst
 }

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -56,6 +56,9 @@ type Limiter struct {
 	// Maximum number of requests to limit per second.
 	max int64
 
+	// Limiter burst size
+	burst int
+
 	// HTTP message when limit is reached.
 	message string
 
@@ -161,6 +164,23 @@ func (l *Limiter) GetMax() int64 {
 	l.RLock()
 	defer l.RUnlock()
 	return l.max
+}
+
+// SetBurst is thread-safe way of setting maximum burst size.
+func (l *Limiter) SetBurst(burst int) *Limiter {
+	l.Lock()
+	l.burst = burst
+	l.Unlock()
+
+	return l
+}
+
+// GetBurst is thread-safe way of setting maximum burst size.
+func (l *Limiter) GetBurst() int {
+	l.RLock()
+	l.RUnlock()
+
+	return l.burst
 }
 
 // SetMessage is thread-safe way of setting HTTP message when limit is reached.
@@ -422,14 +442,14 @@ func (l *Limiter) RemoveHeaderEntries(header string, entriesForRemoval []string)
 
 func (l *Limiter) limitReachedWithTokenBucketTTL(key string, tokenBucketTTL time.Duration) bool {
 	lmtMax := l.GetMax()
-
+	lmtBurst := l.GetBurst()
 	l.Lock()
 	defer l.Unlock()
 
 	if _, found := l.tokenBuckets.Get(key); !found {
 		l.tokenBuckets.Set(
 			key,
-			rate.NewLimiter(rate.Limit(lmtMax), 1),
+			rate.NewLimiter(rate.Limit(lmtMax), lmtBurst),
 			tokenBucketTTL,
 		)
 	}

--- a/limiter/limiter_test.go
+++ b/limiter/limiter_test.go
@@ -33,7 +33,7 @@ func TestConstructorExpiringBuckets(t *testing.T) {
 }
 
 func TestLimitReached(t *testing.T) {
-	lmt := New(nil).SetMax(1)
+	lmt := New(nil).SetMax(1).SetBurst(1)
 	key := "127.0.0.1|/"
 
 	if lmt.LimitReached(key) == true {
@@ -51,7 +51,7 @@ func TestLimitReached(t *testing.T) {
 }
 
 func TestLimitReachedWithCustomTokenBucketTTL(t *testing.T) {
-	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Second, ExpireJobInterval: 0}).SetMax(1)
+	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Second, ExpireJobInterval: 0}).SetMax(1).SetBurst(1)
 	key := "127.0.0.1|/"
 
 	if lmt.LimitReached(key) == true {
@@ -71,7 +71,7 @@ func TestLimitReachedWithCustomTokenBucketTTL(t *testing.T) {
 func TestMuchHigherMaxRequests(t *testing.T) {
 	numRequests := 1000
 	delay := (1 * time.Second) / time.Duration(numRequests)
-	lmt := New(nil).SetMax(int64(numRequests))
+	lmt := New(nil).SetMax(int64(numRequests)).SetBurst(1)
 	key := "127.0.0.1|/"
 
 	for i := 0; i < numRequests; i++ {
@@ -90,7 +90,7 @@ func TestMuchHigherMaxRequests(t *testing.T) {
 func TestMuchHigherMaxRequestsWithCustomTokenBucketTTL(t *testing.T) {
 	numRequests := 1000
 	delay := (1 * time.Second) / time.Duration(numRequests)
-	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Minute, ExpireJobInterval: time.Minute}).SetMax(int64(numRequests))
+	lmt := New(&ExpirableOptions{DefaultExpirationTTL: time.Minute, ExpireJobInterval: time.Minute}).SetMax(int64(numRequests)).SetBurst(1)
 	key := "127.0.0.1|/"
 
 	for i := 0; i < numRequests; i++ {

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -21,7 +21,7 @@ func setResponseHeaders(lmt *limiter.Limiter, w http.ResponseWriter, r *http.Req
 
 // NewLimiter is a convenience function to limiter.New.
 func NewLimiter(max int64, tbOptions *limiter.ExpirableOptions) *limiter.Limiter {
-	return limiter.New(tbOptions).SetMax(max)
+	return limiter.New(tbOptions).SetMax(max).SetBurst(int(max))
 }
 
 // LimitByKeys keeps track number of request made by keys separated by pipe.

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -266,7 +266,7 @@ func TestRequestMethodCustomHeadersAndBasicAuthUsersBuildKeys(t *testing.T) {
 }
 
 func TestLimitHandler(t *testing.T) {
-	lmt := limiter.New(nil).SetMax(1)
+	lmt := limiter.New(nil).SetMax(1).SetBurst(1)
 	lmt.SetIPLookups([]string{"X-Real-IP", "RemoteAddr", "X-Forwarded-For"})
 	lmt.SetMethods([]string{"POST"})
 


### PR DESCRIPTION
PR as discussed in #53:
 - add burst field in Limiter struct
 - modify tollbooth.NewLimiter to default to burst == max
 - add getter and setter for the burst
 - fix tests that are assuming a burst size of 1 and not using the tollbooth.NewLimiter constructor