### PR TITLE
Add TokenBucketKeyExists and RemoveTokenBucketKey functions

### DIFF
--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -440,6 +440,15 @@ func (l *Limiter) RemoveHeaderEntries(header string, entriesForRemoval []string)
 	return l
 }
 
+// TokenBucketKeyExists is a thread-safe way of determining if a particular key exists in the bucket at that moment.
+// A positive result is subject to expiration or removal races, of course.
+func (l *Limiter) TokenBucketKeyExists(key string) bool {
+	l.RLock()
+	_, found := l.tokenBuckets.Get(key)
+	l.RUnlock()
+	return found
+}
+
 func (l *Limiter) limitReachedWithTokenBucketTTL(key string, tokenBucketTTL time.Duration) bool {
 	lmtMax := l.GetMax()
 	lmtBurst := l.GetBurst()

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -440,6 +440,14 @@ func (l *Limiter) RemoveHeaderEntries(header string, entriesForRemoval []string)
 	return l
 }
 
+// RemoveTokenBucketKey is a thread-safe way of removing a key from a bucket.
+func (l *Limiter) RemoveTokenBucketKey(key string) {
+	l.Lock()
+	defer l.Unlock() // defer because possible edge-case panic
+
+	l.tokenBuckets.Delete(key)
+}
+
 // TokenBucketKeyExists is a thread-safe way of determining if a particular key exists in the bucket at that moment.
 // A positive result is subject to expiration or removal races, of course.
 func (l *Limiter) TokenBucketKeyExists(key string) bool {


### PR DESCRIPTION
Used in conjunction with LimitByKeys to implement a bad-request limiter similar to the request of #63 . 