### PR TITLE
Adding context based limits

### DIFF
--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -155,7 +155,7 @@ func (l *Limiter) GetHeaderEntryExpirationTTL() time.Duration {
 }
 
 // SetHeaderEntryExpirationTTL is thread-safe way of setting custom basic auth expiration TTL.
-func (l *Limiter) SetContextEntryEntryExpirationTTL(ttl time.Duration) *Limiter {
+func (l *Limiter) SetContextEntryExpirationTTL(ttl time.Duration) *Limiter {
 	l.Lock()
 	l.contextEntryExpirationTTL = ttl
 	l.Unlock()

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -92,12 +92,16 @@ type Limiter struct {
 	// Empty means skip headers checking.
 	headers map[string]*gocache.Cache
 
+	// Map of Context values to limit.
+	contextValues map[string]*gocache.Cache
+
 	// Map of limiters with TTL
 	tokenBuckets *gocache.Cache
 
-	tokenBucketExpirationTTL time.Duration
-	basicAuthExpirationTTL   time.Duration
-	headerEntryExpirationTTL time.Duration
+	tokenBucketExpirationTTL 	time.Duration
+	basicAuthExpirationTTL   	time.Duration
+	headerEntryExpirationTTL 	time.Duration
+	contextEntryExpirationTTL 	time.Duration
 
 	sync.RWMutex
 }
@@ -148,6 +152,22 @@ func (l *Limiter) GetHeaderEntryExpirationTTL() time.Duration {
 	l.RLock()
 	defer l.RUnlock()
 	return l.headerEntryExpirationTTL
+}
+
+// SetHeaderEntryExpirationTTL is thread-safe way of setting custom basic auth expiration TTL.
+func (l *Limiter) SetContextEntryEntryExpirationTTL(ttl time.Duration) *Limiter {
+	l.Lock()
+	l.contextEntryExpirationTTL = ttl
+	l.Unlock()
+
+	return l
+}
+
+// GetHeaderEntryExpirationTTL is thread-safe way of getting custom basic auth expiration TTL.
+func (l *Limiter) GetContextEntryExpirationTTL() time.Duration {
+	l.RLock()
+	defer l.RUnlock()
+	return l.contextEntryExpirationTTL
 }
 
 // SetMax is thread-safe way of setting maximum number of requests to limit per duration.

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -460,6 +460,26 @@ func (l *Limiter) RemoveHeaderEntries(header string, entriesForRemoval []string)
 	return l
 }
 
+// GetContextValues is thread-safe way of getting a map of Context values to limit.
+func (l *Limiter) GetContextValues() map[string][]string {
+	results := make(map[string][]string)
+
+	l.RLock()
+	defer l.RUnlock()
+
+	for contextValue, entriesAsGoCache := range l.contextValues {
+		entries := make([]string, 0)
+
+		for entry, _ := range entriesAsGoCache.Items() {
+			entries = append(entries, entry)
+		}
+
+		results[contextValue] = entries
+	}
+
+	return results
+}
+
 // SetContextValue is thread-safe way of setting entries of 1 Context value.
 func (l *Limiter) SetContextValue(contextValue string, entries []string) *Limiter {
 	l.RLock()

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -20,7 +20,8 @@ func New(generalExpirableOptions *ExpirableOptions) *Limiter {
 		SetOnLimitReached(nil).
 		SetIPLookups([]string{"RemoteAddr", "X-Forwarded-For", "X-Real-IP"}).
 		SetForwardedForIndexFromBehind(0).
-		SetHeaders(make(map[string][]string))
+		SetHeaders(make(map[string][]string)).
+		SetContextValues(make(map[string][]string))
 
 	if generalExpirableOptions != nil {
 		lmt.generalExpirableOptions = generalExpirableOptions
@@ -455,6 +456,19 @@ func (l *Limiter) RemoveHeaderEntries(header string, entriesForRemoval []string)
 
 	for _, toBeRemoved := range entriesForRemoval {
 		entries.Delete(toBeRemoved)
+	}
+
+	return l
+}
+
+// SetContextValues is thread-safe way of setting map of HTTP headers to limit.
+func (l *Limiter) SetContextValues(contextValues map[string][]string) *Limiter {
+	if l.contextValues == nil {
+		l.contextValues = make(map[string]*gocache.Cache)
+	}
+
+	for contextValue, entries := range contextValues {
+		l.SetContextValue(contextValue, entries)
 	}
 
 	return l

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -444,7 +444,7 @@ func (l *Limiter) RemoveHeader(header string) *Limiter {
 	return l
 }
 
-// RemoveHeaderEntries is thread-safe way of adding new entries to 1 HTTP header rule.
+// RemoveHeaderEntries is thread-safe way of removing new entries to 1 HTTP header rule.
 func (l *Limiter) RemoveHeaderEntries(header string, entriesForRemoval []string) *Limiter {
 	l.RLock()
 	entries, found := l.headers[header]
@@ -500,7 +500,7 @@ func (l *Limiter) SetContextValue(contextValue string, entries []string) *Limite
 	existing, found := l.contextValues[contextValue]
 	l.RUnlock()
 
-	ttl := l.GetContextEntryExpirationTTL()
+	ttl := l.GetContextValueEntryExpirationTTL()
 	if ttl <= 0 {
 		ttl = l.generalExpirableOptions.DefaultExpirationTTL
 	}
@@ -546,6 +546,23 @@ func (l *Limiter) RemoveContextValue(contextValue string) *Limiter {
 	l.Lock()
 	l.contextValues[contextValue] = gocache.New(ttl, l.generalExpirableOptions.ExpireJobInterval)
 	l.Unlock()
+
+	return l
+}
+
+// RemoveContextValuesEntries is thread-safe way of removing entries to a ContextValue.
+func (l *Limiter) RemoveContextValuesEntries(contextValue string, entriesForRemoval []string) *Limiter {
+	l.RLock()
+	entries, found := l.contextValues[contextValue]
+	l.RUnlock()
+
+	if !found {
+		return l
+	}
+
+	for _, toBeRemoved := range entriesForRemoval {
+		entries.Delete(toBeRemoved)
+	}
 
 	return l
 }

--- a/limiter/limiter_setter_getter_test.go
+++ b/limiter/limiter_setter_getter_test.go
@@ -153,3 +153,51 @@ func TestSetGetHeaders(t *testing.T) {
 		t.Errorf("Headers field is incorrect. Value: %v", entries)
 	}
 }
+
+func TestSetGetContextValues(t *testing.T) {
+	lmt := New(nil).SetMax(1)
+
+	// Check default
+	if len(lmt.GetContextValues()) != 0 {
+		t.Errorf("ContextValues field is incorrect. Value: %v", lmt.GetContextValues())
+	}
+
+	contextValues := make(map[string][]string)
+	contextValues["foo"] = []string{"bar"}
+
+	if lmt.SetContextValues(contextValues).GetContextValues()["foo"][0] != "bar" {
+		t.Errorf("ContextValues field is incorrect. Value: %v", lmt.GetContextValues())
+	}
+
+	// Set a new contextValue
+	lmt.SetContextValue("dragons", []string{"drogon", "rhaegal", "viserion"})
+	contextValue := lmt.GetContextValue("dragons")
+
+	if len(contextValue) != 3 {
+		t.Errorf("ContextValues field is incorrect. Value: %v", contextValue)
+	}
+
+	// Remove dragons contextValue
+	lmt.RemoveContextValue("dragons")
+	dragons := lmt.GetContextValue("dragons")
+
+	if len(dragons) != 0 {
+		t.Errorf("ContextValues field is incorrect. Value: %v", dragons)
+	}
+
+	// Adding another entries to an existing contextValue
+	lmt.SetContextValue("foo", []string{"baz"})
+	entries := lmt.GetContextValue("foo")
+
+	if len(entries) != 2 {
+		t.Errorf("ContextValues field is incorrect. Value: %v", entries)
+	}
+
+	// Remove an entry
+	lmt.RemoveContextValuesEntries("foo", []string{"bar"})
+	entries = lmt.GetContextValue("foo")
+
+	if len(entries) != 1 || entries[0] != "baz" {
+		t.Errorf("ContextValues field is incorrect. Value: %v", entries)
+	}
+}

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -59,10 +59,10 @@ func BuildKeys(lmt *limiter.Limiter, r *http.Request) [][]string {
 		if libstring.StringInSlice(lmtMethods, r.Method) {
 			for headerKey, headerValues := range lmtHeaders {
 				if (headerValues == nil || len(headerValues) <= 0) && r.Header.Get(headerKey) != "" {
-					// If header values are empty, rate-limit all request with headerKey.
+					// If header values are empty, rate-limit all request containing headerKey.
 					username, _, ok := r.BasicAuth()
 					if ok && libstring.StringInSlice(lmtBasicAuthUsers, username) {
-						sliceKeys = append(sliceKeys, []string{remoteIP, path, r.Method, headerKey, username})
+						sliceKeys = append(sliceKeys, []string{remoteIP, path, r.Method, headerKey, r.Header.Get(headerKey), username})
 					}
 
 				} else if len(headerValues) > 0 && r.Header.Get(headerKey) != "" {
@@ -71,7 +71,7 @@ func BuildKeys(lmt *limiter.Limiter, r *http.Request) [][]string {
 						if r.Header.Get(headerKey) == headerValue {
 							username, _, ok := r.BasicAuth()
 							if ok && libstring.StringInSlice(lmtBasicAuthUsers, username) {
-								sliceKeys = append(sliceKeys, []string{remoteIP, path, r.Method, headerKey, headerValue})
+								sliceKeys = append(sliceKeys, []string{remoteIP, path, r.Method, headerKey, headerValue, username})
 							}
 							break
 						}
@@ -86,7 +86,7 @@ func BuildKeys(lmt *limiter.Limiter, r *http.Request) [][]string {
 			for headerKey, headerValues := range lmtHeaders {
 				if (headerValues == nil || len(headerValues) <= 0) && r.Header.Get(headerKey) != "" {
 					// If header values are empty, rate-limit all request with headerKey.
-					sliceKeys = append(sliceKeys, []string{remoteIP, path, r.Method, headerKey})
+					sliceKeys = append(sliceKeys, []string{remoteIP, path, r.Method, headerKey, r.Header.Get(headerKey)})
 
 				} else if len(headerValues) > 0 && r.Header.Get(headerKey) != "" {
 					// We are only limiting if request's header value is defined inside `headerValues`.
@@ -120,7 +120,7 @@ func BuildKeys(lmt *limiter.Limiter, r *http.Request) [][]string {
 		for headerKey, headerValues := range lmtHeaders {
 			if (headerValues == nil || len(headerValues) <= 0) && r.Header.Get(headerKey) != "" {
 				// If header values are empty, rate-limit all request with headerKey.
-				sliceKeys = append(sliceKeys, []string{remoteIP, path, headerKey})
+				sliceKeys = append(sliceKeys, []string{remoteIP, path, headerKey, r.Header.Get(headerKey)})
 
 			} else if len(headerValues) > 0 && r.Header.Get(headerKey) != "" {
 				// If header values are not empty, rate-limit all request with headerKey and headerValues.

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -89,8 +89,7 @@ func BuildKeys(lmt *limiter.Limiter, r *http.Request) [][]string {
 				}
 			}
 		}
-	}
-	if len(headerValuesToLimit) <= 0 {
+	} else {
 		headerValuesToLimit = append(headerValuesToLimit, []string{"", ""})
 	}
 

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -23,7 +23,10 @@ func setResponseHeaders(lmt *limiter.Limiter, w http.ResponseWriter, r *http.Req
 
 // NewLimiter is a convenience function to limiter.New.
 func NewLimiter(max float64, tbOptions *limiter.ExpirableOptions) *limiter.Limiter {
-	return limiter.New(tbOptions).SetMax(max).SetBurst(int(math.Max(1, max)))
+	return limiter.New(tbOptions).
+		SetMax(max).
+		SetBurst(int(math.Max(1, max))).
+		SetIPLookups([]string{"X-Forwarded-For", "X-Real-IP", "RemoteAddr"})
 }
 
 // LimitByKeys keeps track number of request made by keys separated by pipe.

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -48,14 +48,18 @@ func TestDefaultBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		for i, keyChunk := range keys {
-			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
-				t.Errorf("The first chunk should be remote IP. KeyChunk: %v", keyChunk)
-			}
-			if i == 1 && keyChunk != request.URL.Path {
-				t.Errorf("The second chunk should be request path. KeyChunk: %v", keyChunk)
-			}
+		expectedKeys := [][]string{
+			{request.Header.Get("X-Real-IP")},
+			{request.URL.Path},
+			{""},
+			{""},
+			{""},
+			{""},
+			{""},
+			{""},
 		}
+
+		checkKeys(t, keys,expectedKeys )
 	}
 }
 
@@ -78,21 +82,19 @@ func TestBasicAuthBuildKeys(t *testing.T) {
 		t.Fatal("Length of sliceKeys should never be empty.")
 	}
 
-	for _, keys := range BuildKeys(lmt, request) {
-		if len(keys) != 6 {
-			t.Error("Keys should be made of 6 parts.")
+	for _, keys := range sliceKeys {
+		expectedKeys := [][]string{
+			{request.Header.Get("X-Real-IP")},
+			{request.URL.Path},
+			{""},
+			{""},
+			{""},
+			{""},
+			{""},
+			{"bro"},
 		}
-		for i, keyChunk := range keys {
-			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
-				t.Errorf("The (%v) chunk should be remote IP. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 1 && keyChunk != request.URL.Path {
-				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 5 && keyChunk != "bro" {
-				t.Errorf("The (%v) chunk should be request username. KeyChunk: %v", i+1, keyChunk)
-			}
-		}
+
+		checkKeys(t, keys,expectedKeys )
 	}
 }
 
@@ -115,23 +117,18 @@ func TestCustomHeadersBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		if len(keys) != 6 {
-			t.Errorf("Keys should be made of 6 parts. Keys: %v", keys)
+		expectedKeys := [][]string{
+			{request.Header.Get("X-Real-IP")},
+			{request.URL.Path},
+			{""},
+			{"X-Auth-Token"},
+			{"totally-top-secret", "another-secret"},
+			{""},
+			{""},
+			{""},
 		}
-		for i, keyChunk := range keys {
-			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
-				t.Errorf("The (%v) chunk should be remote IP. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 1 && keyChunk != request.URL.Path {
-				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 3 && keyChunk != "X-Auth-Token" {
-				t.Errorf("The (%v) chunk should be request header. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 4 && (keyChunk != "totally-top-secret" && keyChunk != "another-secret") {
-				t.Errorf("The (%v) chunk should be request header value. KeyChunk: %v", i+1, keyChunk)
-			}
-		}
+
+		checkKeys(t, keys,expectedKeys )
 	}
 }
 
@@ -153,20 +150,18 @@ func TestRequestMethodBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		if len(keys) != 6 {
-			t.Errorf("Keys should be made of 6 parts. Keys: %v", keys)
+		expectedKeys := [][]string{
+			{request.Header.Get("X-Real-IP")},
+			{request.URL.Path},
+			{"GET"},
+			{""},
+			{""},
+			{""},
+			{""},
+			{""},
 		}
-		for i, keyChunk := range keys {
-			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
-				t.Errorf("The (%v) chunk should be remote IP. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 1 && keyChunk != request.URL.Path {
-				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 2 && keyChunk != "GET" {
-				t.Errorf("The (%v) chunk should be request method. KeyChunk: %v", i+1, keyChunk)
-			}
-		}
+
+		checkKeys(t, keys,expectedKeys )
 	}
 }
 
@@ -189,27 +184,18 @@ func TestContextValueBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		checkKeys(keys, t, request)
-	}
-}
+		expectedKeys := [][]string{
+			{request.Header.Get("X-Real-IP")},
+			{request.URL.Path},
+			{""},
+			{""},
+			{""},
+			{"API-access-level"},
+			{"basic"},
+			{""},
+		}
 
-func checkKeys(keys []string, t *testing.T, request *http.Request) {
-	if len(keys) != 8 {
-		t.Errorf("Keys should be made of 8 parts. Keys: %v", keys)
-	}
-	for i, keyChunk := range keys {
-		if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
-			t.Errorf("The (%v) chunk should be remote IP. KeyChunk: %v", i+1, keyChunk)
-		}
-		if i == 1 && keyChunk != request.URL.Path {
-			t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
-		}
-		if i == 5 && keyChunk != "API-access-level" {
-			t.Errorf("The (%v) chunk should be context key. KeyChunk: %v", i+1, keyChunk)
-		}
-		if i == 6 && keyChunk != "basic" {
-			t.Errorf("The (%v) chunk should be context value. KeyChunk: %v", i+1, keyChunk)
-		}
+		checkKeys(t, keys,expectedKeys )
 	}
 }
 
@@ -233,26 +219,18 @@ func TestRequestMethodAndCustomHeadersBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		if len(keys) != 6 {
-			t.Errorf("Keys should be made of 6 parts. Keys: %v", keys)
+		expectedKeys := [][]string{
+			{request.Header.Get("X-Real-IP")},
+			{request.URL.Path},
+			{"GET"},
+			{"X-Auth-Token"},
+			{"totally-top-secret", "another-secret"},
+			{""},
+			{""},
+			{""},
 		}
-		for i, keyChunk := range keys {
-			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
-				t.Errorf("The (%v) chunk should be remote IP. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 1 && keyChunk != request.URL.Path {
-				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 2 && keyChunk != "GET" {
-				t.Errorf("The (%v) chunk should be request method. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 3 && keyChunk != "X-Auth-Token" {
-				t.Errorf("The (%v) chunk should be request header. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 4 && (keyChunk != "totally-top-secret" && keyChunk != "another-secret") {
-				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
-			}
-		}
+
+		checkKeys(t, keys,expectedKeys )
 	}
 }
 
@@ -276,23 +254,18 @@ func TestRequestMethodAndBasicAuthUsersBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		if len(keys) != 6 {
-			t.Errorf("Keys should be made of 6 parts. Keys: %v", keys)
+		expectedKeys := [][]string{
+			{request.Header.Get("X-Real-IP")},
+			{request.URL.Path},
+			{"GET"},
+			{""},
+			{""},
+			{""},
+			{""},
+			{"bro"},
 		}
-		for i, keyChunk := range keys {
-			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
-				t.Errorf("The (%v) chunk should be remote IP. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 1 && keyChunk != request.URL.Path {
-				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 2 && keyChunk != "GET" {
-				t.Errorf("The (%v) chunk should be request method. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 5 && keyChunk != "bro" {
-				t.Errorf("The (%v) chunk should be basic auth user. KeyChunk: %v", i+1, keyChunk)
-			}
-		}
+
+		checkKeys(t, keys,expectedKeys )
 	}
 }
 
@@ -318,29 +291,18 @@ func TestRequestMethodCustomHeadersAndBasicAuthUsersBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		if len(keys) != 6 {
-			t.Errorf("Keys should be made of 4 parts. Keys: %v", keys)
+		expectedKeys := [][]string{
+			{request.Header.Get("X-Real-IP")},
+			{request.URL.Path},
+			{"GET"},
+			{"X-Auth-Token"},
+			{"totally-top-secret", "another-secret"},
+			{""},
+			{""},
+			{"bro"},
 		}
-		for i, keyChunk := range keys {
-			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
-				t.Errorf("The (%v) chunk should be remote IP. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 1 && keyChunk != request.URL.Path {
-				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 2 && keyChunk != "GET" {
-				t.Errorf("The (%v) chunk should be request method. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 3 && keyChunk != "X-Auth-Token" {
-				t.Errorf("The (%v) chunk should be request header. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 4 && (keyChunk != "totally-top-secret" && keyChunk != "another-secret") {
-				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 5 && keyChunk != "bro" {
-				t.Errorf("The (%v) chunk should be basic auth user. KeyChunk: %v", i+1, keyChunk)
-			}
-		}
+
+		checkKeys(t, keys,expectedKeys )
 	}
 }
 
@@ -385,4 +347,39 @@ func TestLimitHandler(t *testing.T) {
 		close(ch)
 	}()
 	<-ch // Block until go func is done.
+}
+
+func checkKeys(t *testing.T, keys []string, expectedKeys [][]string) {
+	if len(keys) != 8 {
+		t.Errorf("Keys should be made of 8 parts. Keys: %v", keys)
+	}
+
+	for i, keyChunk := range keys {
+		if i == 0 && !isInSlice(keyChunk, expectedKeys[0]) {
+			t.Errorf("The (%v) chunk should be remote IP. KeyChunk: %v", i+1, keyChunk)
+		} else if i == 1 && !isInSlice(keyChunk, expectedKeys[1]) {
+			t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
+		} else if i == 2 && !isInSlice(keyChunk, expectedKeys[2]) {
+			t.Errorf("The (%v) chunk should be request method. KeyChunk: %v", i+1, keyChunk)
+		} else if i == 3 && !isInSlice(keyChunk, expectedKeys[3]) {
+			t.Errorf("The (%v) chunk should be request header. KeyChunk: %v", i+1, keyChunk)
+		} else if i == 4 && !isInSlice(keyChunk, expectedKeys[4]) {
+			t.Errorf("The (%v) chunk should be request header value. KeyChunk: %v", i+1, keyChunk)
+		} else if i == 5 && !isInSlice(keyChunk, expectedKeys[5]) {
+			t.Errorf("The (%v) chunk should be context key. KeyChunk: %v", i+1, keyChunk)
+		} else if i == 6 && !isInSlice(keyChunk, expectedKeys[6]) {
+			t.Errorf("The (%v) chunk should be context value. KeyChunk: %v", i+1, keyChunk)
+		} else if i == 7 && !isInSlice(keyChunk, expectedKeys[7]) {
+			t.Errorf("The (%v) chunk should be basic auth user. KeyChunk: %v", i+1, keyChunk)
+		}
+	}
+}
+
+func isInSlice(key string, keys []string) bool {
+	for _, sliceKey := range keys {
+		if key == sliceKey {
+			return true
+		}
+	}
+	return false
 }

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -189,22 +189,26 @@ func TestContextValueBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		if len(keys) != 8 {
-			t.Errorf("Keys should be made of 8 parts. Keys: %v", keys)
+		checkKeys(keys, t, request)
+	}
+}
+
+func checkKeys(keys []string, t *testing.T, request *http.Request) {
+	if len(keys) != 8 {
+		t.Errorf("Keys should be made of 8 parts. Keys: %v", keys)
+	}
+	for i, keyChunk := range keys {
+		if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
+			t.Errorf("The (%v) chunk should be remote IP. KeyChunk: %v", i+1, keyChunk)
 		}
-		for i, keyChunk := range keys {
-			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
-				t.Errorf("The (%v) chunk should be remote IP. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 1 && keyChunk != request.URL.Path {
-				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 5 && keyChunk != "API-access-level" {
-				t.Errorf("The (%v) chunk should be context key. KeyChunk: %v", i+1, keyChunk)
-			}
-			if i == 6 && keyChunk != "basic" {
-				t.Errorf("The (%v) chunk should be context value. KeyChunk: %v", i+1, keyChunk)
-			}
+		if i == 1 && keyChunk != request.URL.Path {
+			t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
+		}
+		if i == 5 && keyChunk != "API-access-level" {
+			t.Errorf("The (%v) chunk should be context key. KeyChunk: %v", i+1, keyChunk)
+		}
+		if i == 6 && keyChunk != "basic" {
+			t.Errorf("The (%v) chunk should be context value. KeyChunk: %v", i+1, keyChunk)
 		}
 	}
 }

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -125,6 +125,7 @@ func TestCustomHeadersBuildKeys(t *testing.T) {
 func TestRequestMethodBuildKeys(t *testing.T) {
 	lmt := NewLimiter(1, nil)
 	lmt.SetMethods([]string{"GET"})
+	lmt.SetIPLookups([]string{"X-Forwarded-For", "X-Real-IP", "RemoteAddr"})
 
 	request, err := http.NewRequest("GET", "/", strings.NewReader("Hello, world!"))
 	if err != nil {
@@ -133,7 +134,13 @@ func TestRequestMethodBuildKeys(t *testing.T) {
 
 	request.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
 
-	for _, keys := range BuildKeys(lmt, request) {
+	allKeys := BuildKeys(lmt, request)
+
+	if len(allKeys) != 1 {
+		t.Errorf("There should be exactly one key. AllKeys: %v", allKeys)
+	}
+
+	for _, keys := range allKeys {
 		if len(keys) != 3 {
 			t.Errorf("Keys should be made of 3 parts. Keys: %v", keys)
 		}

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -33,7 +33,6 @@ func TestLimitByKeys(t *testing.T) {
 
 func TestDefaultBuildKeys(t *testing.T) {
 	lmt := NewLimiter(1, nil)
-	lmt.SetIPLookups([]string{"X-Forwarded-For", "X-Real-IP", "RemoteAddr"})
 
 	request, err := http.NewRequest("GET", "/", strings.NewReader("Hello, world!"))
 	if err != nil {
@@ -65,7 +64,6 @@ func TestDefaultBuildKeys(t *testing.T) {
 
 func TestBasicAuthBuildKeys(t *testing.T) {
 	lmt := NewLimiter(1, nil)
-	lmt.SetIPLookups([]string{"X-Forwarded-For", "X-Real-IP", "RemoteAddr"})
 	lmt.SetBasicAuthUsers([]string{"bro"})
 
 	request, err := http.NewRequest("GET", "/", strings.NewReader("Hello, world!"))
@@ -100,7 +98,6 @@ func TestBasicAuthBuildKeys(t *testing.T) {
 
 func TestCustomHeadersBuildKeys(t *testing.T) {
 	lmt := NewLimiter(1, nil)
-	lmt.SetIPLookups([]string{"X-Forwarded-For", "X-Real-IP", "RemoteAddr"})
 	lmt.SetHeader("X-Auth-Token", []string{"totally-top-secret", "another-secret"})
 
 	request, err := http.NewRequest("GET", "/", strings.NewReader("Hello, world!"))
@@ -134,7 +131,6 @@ func TestCustomHeadersBuildKeys(t *testing.T) {
 
 func TestRequestMethodBuildKeys(t *testing.T) {
 	lmt := NewLimiter(1, nil)
-	lmt.SetIPLookups([]string{"X-Forwarded-For", "X-Real-IP", "RemoteAddr"})
 	lmt.SetMethods([]string{"GET"})
 
 	request, err := http.NewRequest("GET", "/", strings.NewReader("Hello, world!"))
@@ -167,7 +163,6 @@ func TestRequestMethodBuildKeys(t *testing.T) {
 
 func TestContextValueBuildKeys(t *testing.T) {
 	lmt := NewLimiter(1, nil)
-	lmt.SetIPLookups([]string{"X-Forwarded-For", "X-Real-IP", "RemoteAddr"})
 	lmt.SetContextValue("API-access-level", []string{"basic"})
 
 	request, err := http.NewRequest("GET", "/", strings.NewReader("Hello, world!"))
@@ -201,7 +196,6 @@ func TestContextValueBuildKeys(t *testing.T) {
 
 func TestRequestMethodAndCustomHeadersBuildKeys(t *testing.T) {
 	lmt := NewLimiter(1, nil)
-	lmt.SetIPLookups([]string{"X-Forwarded-For", "X-Real-IP", "RemoteAddr"})
 	lmt.SetMethods([]string{"GET"})
 	lmt.SetHeader("X-Auth-Token", []string{"totally-top-secret", "another-secret"})
 
@@ -236,7 +230,6 @@ func TestRequestMethodAndCustomHeadersBuildKeys(t *testing.T) {
 
 func TestRequestMethodAndBasicAuthUsersBuildKeys(t *testing.T) {
 	lmt := NewLimiter(1, nil)
-	lmt.SetIPLookups([]string{"X-Forwarded-For", "X-Real-IP", "RemoteAddr"})
 	lmt.SetMethods([]string{"GET"})
 	lmt.SetBasicAuthUsers([]string{"bro"})
 
@@ -271,7 +264,6 @@ func TestRequestMethodAndBasicAuthUsersBuildKeys(t *testing.T) {
 
 func TestRequestMethodCustomHeadersAndBasicAuthUsersBuildKeys(t *testing.T) {
 	lmt := NewLimiter(1, nil)
-	lmt.SetIPLookups([]string{"X-Forwarded-For", "X-Real-IP", "RemoteAddr"})
 	lmt.SetMethods([]string{"GET"})
 	lmt.SetHeader("X-Auth-Token", []string{"totally-top-secret", "another-secret"})
 	lmt.SetBasicAuthUsers([]string{"bro"})
@@ -308,7 +300,6 @@ func TestRequestMethodCustomHeadersAndBasicAuthUsersBuildKeys(t *testing.T) {
 
 func TestRequestMethodCustomHeadersAndBasicAuthUsersAndContextValuesBuildKeys(t *testing.T) {
 	lmt := NewLimiter(1, nil)
-	lmt.SetIPLookups([]string{"X-Forwarded-For", "X-Real-IP", "RemoteAddr"})
 	lmt.SetMethods([]string{"GET"})
 	lmt.SetHeader("X-Auth-Token", []string{"totally-top-secret", "another-secret"})
 	lmt.SetContextValue("API-access-level", []string{"basic"})

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -116,7 +116,7 @@ func TestCustomHeadersBuildKeys(t *testing.T) {
 				t.Errorf("The (%v) chunk should be request header. KeyChunk: %v", i+1, keyChunk)
 			}
 			if i == 3 && (keyChunk != "totally-top-secret" && keyChunk != "another-secret") {
-				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
+				t.Errorf("The (%v) chunk should be request header value. KeyChunk: %v", i+1, keyChunk)
 			}
 		}
 	}

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -78,8 +78,8 @@ func TestBasicAuthBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range BuildKeys(lmt, request) {
-		if len(keys) != 3 {
-			t.Error("Keys should be made of 3 parts.")
+		if len(keys) != 6 {
+			t.Error("Keys should be made of 6 parts.")
 		}
 		for i, keyChunk := range keys {
 			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
@@ -88,7 +88,7 @@ func TestBasicAuthBuildKeys(t *testing.T) {
 			if i == 1 && keyChunk != request.URL.Path {
 				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
 			}
-			if i == 2 && keyChunk != "bro" {
+			if i == 5 && keyChunk != "bro" {
 				t.Errorf("The (%v) chunk should be request username. KeyChunk: %v", i+1, keyChunk)
 			}
 		}
@@ -114,8 +114,8 @@ func TestCustomHeadersBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		if len(keys) != 4 {
-			t.Errorf("Keys should be made of 4 parts. Keys: %v", keys)
+		if len(keys) != 6 {
+			t.Errorf("Keys should be made of 6 parts. Keys: %v", keys)
 		}
 		for i, keyChunk := range keys {
 			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
@@ -124,10 +124,10 @@ func TestCustomHeadersBuildKeys(t *testing.T) {
 			if i == 1 && keyChunk != request.URL.Path {
 				t.Errorf("The (%v) chunk should be request path. KeyChunk: %v", i+1, keyChunk)
 			}
-			if i == 2 && keyChunk != "X-Auth-Token" {
+			if i == 3 && keyChunk != "X-Auth-Token" {
 				t.Errorf("The (%v) chunk should be request header. KeyChunk: %v", i+1, keyChunk)
 			}
-			if i == 3 && (keyChunk != "totally-top-secret" && keyChunk != "another-secret") {
+			if i == 4 && (keyChunk != "totally-top-secret" && keyChunk != "another-secret") {
 				t.Errorf("The (%v) chunk should be request header value. KeyChunk: %v", i+1, keyChunk)
 			}
 		}
@@ -152,8 +152,8 @@ func TestRequestMethodBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		if len(keys) != 3 {
-			t.Errorf("Keys should be made of 3 parts. Keys: %v", keys)
+		if len(keys) != 6 {
+			t.Errorf("Keys should be made of 6 parts. Keys: %v", keys)
 		}
 		for i, keyChunk := range keys {
 			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
@@ -189,8 +189,8 @@ func TestRequestMethodAndCustomHeadersBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		if len(keys) != 5 {
-			t.Errorf("Keys should be made of 4 parts. Keys: %v", keys)
+		if len(keys) != 6 {
+			t.Errorf("Keys should be made of 6 parts. Keys: %v", keys)
 		}
 		for i, keyChunk := range keys {
 			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
@@ -232,8 +232,8 @@ func TestRequestMethodAndBasicAuthUsersBuildKeys(t *testing.T) {
 	}
 
 	for _, keys := range sliceKeys {
-		if len(keys) != 4 {
-			t.Errorf("Keys should be made of 4 parts. Keys: %v", keys)
+		if len(keys) != 6 {
+			t.Errorf("Keys should be made of 6 parts. Keys: %v", keys)
 		}
 		for i, keyChunk := range keys {
 			if i == 0 && keyChunk != request.Header.Get("X-Real-IP") {
@@ -245,7 +245,7 @@ func TestRequestMethodAndBasicAuthUsersBuildKeys(t *testing.T) {
 			if i == 2 && keyChunk != "GET" {
 				t.Errorf("The (%v) chunk should be request method. KeyChunk: %v", i+1, keyChunk)
 			}
-			if i == 3 && keyChunk != "bro" {
+			if i == 5 && keyChunk != "bro" {
 				t.Errorf("The (%v) chunk should be basic auth user. KeyChunk: %v", i+1, keyChunk)
 			}
 		}


### PR DESCRIPTION
Implements #74. It also contains the test fixes of #75.

I had to completely change the `BuildKeys` method: it was very difficult to modify to add this change due to the combinatorial complexity of all cases.
I am not sure of all the impacts. There is probably a small performance/memory penalty but I am more worried about if it still works correctly (even if all tests passes).
Let me know what you think!

I created a `checkKeys` method in the test to validate the return of the `BuildKeys` method. Not sure if you'll find it useful.

Context values can be of any type, so I converted it to a string with a `Sprintf` but there is probably a better/cleaner way of doing thing.

Finally, I did a lot of commits to go there, I can squash most of them if you prefer.