### PR TITLE
Fix import paths to use tollbooth/v5 module

### DIFF
--- a/tollbooth.go
+++ b/tollbooth.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/didip/tollbooth/errors"
-	"github.com/didip/tollbooth/libstring"
-	"github.com/didip/tollbooth/limiter"
+	"github.com/didip/tollbooth/v5/errors"
+	"github.com/didip/tollbooth/v5/libstring"
+	"github.com/didip/tollbooth/v5/limiter"
 )
 
 // setResponseHeaders configures X-Rate-Limit-Limit and X-Rate-Limit-Duration

--- a/tollbooth_benchmark_test.go
+++ b/tollbooth_benchmark_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/didip/tollbooth/limiter"
+	"github.com/didip/tollbooth/v5/limiter"
 )
 
 func BenchmarkLimitByKeys(b *testing.B) {

--- a/tollbooth_bug_report_test.go
+++ b/tollbooth_bug_report_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/didip/tollbooth/limiter"
+	"github.com/didip/tollbooth/v5/limiter"
 )
 
 // See: https://github.com/didip/tollbooth/issues/48

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/didip/tollbooth/limiter"
+	"github.com/didip/tollbooth/v5/limiter"
 )
 
 func TestLimitByKeys(t *testing.T) {


### PR DESCRIPTION
The import paths within tollbooth must also use the v5 paths, otherwise tollbooth will be returning pre-v5 types.