### PR TITLE
bump tollbooth internal references to v6, go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.12
 
 require (
 	github.com/go-pkgz/expirable-cache v0.0.3
-	golang.org/x/net v0.0.0-20161007143504-f4b625ec9b21 // indirect
-	golang.org/x/time v0.0.0-20160926182426-711ca1cb8763
+	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1
 )

--- a/go.sum
+++ b/go.sum
@@ -9,10 +9,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-golang.org/x/net v0.0.0-20161007143504-f4b625ec9b21 h1:oOvUY3V+5DQQG3Bgf/tgq5syFCPvlosk3Hm5JFKmDGg=
-golang.org/x/net v0.0.0-20161007143504-f4b625ec9b21/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/time v0.0.0-20160926182426-711ca1cb8763 h1:ryh+9pccLWKRcDnumRJGpcEl5IuQKPM5WgAItYcz09Q=
-golang.org/x/time v0.0.0-20160926182426-711ca1cb8763/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 h1:NusfzzA6yGQ+ua51ck7E3omNUX/JuqbFSaRGqU8CcLI=
+golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/didip/tollbooth/v5/errors"
-	"github.com/didip/tollbooth/v5/libstring"
-	"github.com/didip/tollbooth/v5/limiter"
+	"github.com/didip/tollbooth/v6/errors"
+	"github.com/didip/tollbooth/v6/libstring"
+	"github.com/didip/tollbooth/v6/limiter"
 )
 
 // setResponseHeaders configures X-Rate-Limit-Limit and X-Rate-Limit-Duration

--- a/tollbooth_benchmark_test.go
+++ b/tollbooth_benchmark_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/didip/tollbooth/v5/limiter"
+	"github.com/didip/tollbooth/v6/limiter"
 )
 
 func BenchmarkLimitByKeys(b *testing.B) {

--- a/tollbooth_bug_report_test.go
+++ b/tollbooth_bug_report_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/didip/tollbooth/v5/limiter"
+	"github.com/didip/tollbooth/v6/limiter"
 )
 
 // See: https://github.com/didip/tollbooth/issues/48

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/didip/tollbooth/v5/limiter"
+	"github.com/didip/tollbooth/v6/limiter"
 )
 
 func TestLimitByKeys(t *testing.T) {


### PR DESCRIPTION
Missing piece of puzzle. Otherwise: `../../../go/pkg/mod/github.com/didip/tollbooth_chi@v0.0.0-20200524181329-8b84cd7183d9/tollbooth_chi.go:33:42: cannot use l.lmt (type *"github.com/didip/tollbooth/v6/limiter".Limiter) as type *"github.com/didip/tollbooth/v5/limiter".Limiter in argument to tollbooth.LimitByRequest`