### PR TITLE
add ability to send back something other than the default

### DIFF
--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -61,6 +61,9 @@ type Limiter struct {
 	// A function to call when a request is rejected.
 	onLimitReached func(w http.ResponseWriter, r *http.Request)
 
+	// An option to write back what you want upon reaching a limit.
+	overrideDefaultResponseWriter bool
+
 	// List of places to look up IP address.
 	// Default is "RemoteAddr", "X-Forwarded-For", "X-Real-IP".
 	// You can rearrange the order as you like.
@@ -259,6 +262,18 @@ func (l *Limiter) ExecOnLimitReached(w http.ResponseWriter, r *http.Request) {
 	if fn != nil {
 		fn(w, r)
 	}
+}
+
+func (l *Limiter) SetOverrideDefaultResponseWriter(override bool) {
+	l.Lock()
+	l.overrideDefaultResponseWriter = override
+	l.Unlock()
+}
+
+func (l *Limiter) GetOverrideDefaultResponseWriter() bool {
+	l.RLock()
+	defer l.RUnlock()
+	return l.overrideDefaultResponseWriter
 }
 
 // SetIPLookups is thread-safe way of setting list of places to look up IP address.

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -264,12 +264,14 @@ func (l *Limiter) ExecOnLimitReached(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// SetOverrideDefaultResponseWriter is a thread-safe way of setting the response writer override variable.
 func (l *Limiter) SetOverrideDefaultResponseWriter(override bool) {
 	l.Lock()
 	l.overrideDefaultResponseWriter = override
 	l.Unlock()
 }
 
+// SetOverrideDefaultResponseWriter is a thread-safe way of getting the response writer override variable.
 func (l *Limiter) GetOverrideDefaultResponseWriter() bool {
 	l.RLock()
 	defer l.RUnlock()

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -271,7 +271,7 @@ func (l *Limiter) SetOverrideDefaultResponseWriter(override bool) {
 	l.Unlock()
 }
 
-// SetOverrideDefaultResponseWriter is a thread-safe way of getting the response writer override variable.
+// GetOverrideDefaultResponseWriter is a thread-safe way of getting the response writer override variable.
 func (l *Limiter) GetOverrideDefaultResponseWriter() bool {
 	l.RLock()
 	defer l.RUnlock()

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -156,6 +156,9 @@ func LimitHandler(lmt *limiter.Limiter, next http.Handler) http.Handler {
 		httpError := LimitByRequest(lmt, w, r)
 		if httpError != nil {
 			lmt.ExecOnLimitReached(w, r)
+			if lmt.GetOverrideDefaultResponseWriter() {
+				return
+			}
 			w.Header().Add("Content-Type", lmt.GetMessageContentType())
 			w.WriteHeader(httpError.StatusCode)
 			w.Write([]byte(httpError.Message))

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -381,6 +381,55 @@ func TestLimitHandler(t *testing.T) {
 	<-ch // Block until go func is done.
 }
 
+func TestOverrideForResponseWriter(t *testing.T) {
+	lmt := limiter.New(nil).SetMax(1).SetBurst(1)
+	lmt.SetIPLookups([]string{"X-Real-IP", "RemoteAddr", "X-Forwarded-For"})
+	lmt.SetMethods([]string{"POST"})
+	lmt.SetOverrideDefaultResponseWriter(true)
+
+	counter := 0
+	lmt.SetOnLimitReached(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotAcceptable)
+		w.Write([]byte("rejecting the large amount of requests"))
+		counter++
+	})
+
+	handler := LimitHandler(lmt, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`hello world`))
+	}))
+
+	req, err := http.NewRequest("POST", "/doesntmatter", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	// Should not be limited
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	ch := make(chan int)
+	go func() {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		// Should be limited
+		if status := rr.Code; status != http.StatusNotAcceptable {
+			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusNotAcceptable)
+		}
+		// OnLimitReached should be called
+		if counter != 1 {
+			t.Errorf("onLimitReached was not called")
+		}
+		close(ch)
+	}()
+	<-ch // Block until go func is done.
+}
+
 func checkKeys(t *testing.T, keys []string, expectedKeys [][]string) {
 	if len(keys) != 8 {
 		t.Errorf("Keys should be made of 8 parts. Keys: %v", keys)


### PR DESCRIPTION
**Why:**
- the test is just a basic check that you can override what's originally sent, but the actual reason for this override originates from the desire to use this wonderful repo in one of my applications, but I am required to send back a special error proto object not just a simple message. (on top of that, the responses content type often toggles in-between application/json & application/x-protobuf)
- it would be super cool if I could control the full process of what happens when the limit is reached, including what get's sent back to the user ( currently if I send it back what I want, I get trouble when it tries to write back twice )

**What:**
- this override when set allows the user to control the full process of what get's written back
- the override defaults to false unless users go out of their way to change it. So all original behavior stays the same.

**Tests:**
- all previous test still pass
- added very basic test for proof of concept
