### PR TITLE
Add DeleteExpiredTokenBuckets method limiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /debug
 /.vscode
+/.idea

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -374,6 +374,11 @@ func (l *Limiter) RemoveBasicAuthUsers(basicAuthUsers []string) *Limiter {
 	return l
 }
 
+// DeleteExpiredTokenBuckets is thread-safe way of deleting expired token buckets
+func (l *Limiter) DeleteExpiredTokenBuckets() {
+	l.tokenBuckets.DeleteExpired()
+}
+
 // SetHeaders is thread-safe way of setting map of HTTP headers to limit.
 func (l *Limiter) SetHeaders(headers map[string][]string) *Limiter {
 	if l.headers == nil {


### PR DESCRIPTION
As written here https://github.com/go-pkgz/expirable-cache/blob/master/README.md, the only reliable way of not having expired entries stuck in a cache is to run cache.DeleteExpired periodically using time.Ticker, but we can not call DeleteExpired method of tokenBuckets property of Limiter struct, cause it is private property. So, we need some public method that calls DeleteExpired method tokenBuckets cache.

If we do not clear the memory from time to time, then we will have up to a max count of requests at TTL duration expired tokens. 