### PR TITLE
Block by IPv6 /64 rather than individual addresses

### DIFF
--- a/libstring/libstring.go
+++ b/libstring/libstring.go
@@ -53,3 +53,50 @@ func RemoteIP(ipLookups []string, forwardedForIndexFromBehind int, r *http.Reque
 
 	return ""
 }
+
+// CanonicalizeIP returns a form of ip suitable for comparison to other IPs.
+// For IPv4 addresses, this is simply the whole string.
+// For IPv6 addresses, this is the /64 prefix.
+func CanonicalizeIP(ip string) string {
+	isIPv6 := false
+	// This is how net.ParseIP decides if an address is IPv6
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.7:src/net/ip.go;l=704
+	for i := 0; !isIPv6 && i < len(ip); i++ {
+		switch ip[i] {
+		case '.':
+			// IPv4
+			return ip
+		case ':':
+			// IPv6
+			isIPv6 = true
+			break
+		}
+	}
+	if !isIPv6 {
+		// Not an IP address at all
+		return ip
+	}
+
+	// By default, the string representation of a net.IPNet (masked IP address) is just
+	// "full_address/mask_bits". But using that will result in different addresses with
+	// the same /64 prefix comparing differently. So we need to zero out the last 64 bits
+	// so that all IPs in the same prefix will be the same.
+	//
+	// Note: When 1.18 is the minimum Go version, this can be written more cleanly like:
+	// netip.PrefixFrom(netip.MustParseAddr(ipv6), 64).Masked().Addr().String()
+	// (With appropriate error checking.)
+
+	ipv6 := net.ParseIP(ip)
+	if ipv6 == nil {
+		return ip
+	}
+
+	const bytesToZero = (128 - 64) / 8
+	for i := len(ipv6) - bytesToZero; i < len(ipv6); i++ {
+		ipv6[i] = 0
+	}
+
+	// Note that this doesn't have the "/64" suffix customary with a CIDR representation,
+	// but those three bytes add nothing for us.
+	return ipv6.String()
+}

--- a/libstring/libstring_test.go
+++ b/libstring/libstring_test.go
@@ -120,3 +120,59 @@ func TestRemoteIPMultipleForwardedFor(t *testing.T) {
 		t.Errorf("X-Real-IP should have been skipped. IP: %v", ip)
 	}
 }
+
+func TestCanonicalizeIP(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want string
+	}{
+		{
+			name: "IPv4 unchanged",
+			ip:   "1.2.3.4",
+			want: "1.2.3.4",
+		},
+		{
+			name: "bad IP unchanged",
+			ip:   "not an IP",
+			want: "not an IP",
+		},
+		{
+			name: "bad IPv6 unchanged",
+			ip:   "not:an:IP",
+			want: "not:an:IP",
+		},
+		{
+			name: "empty string unchanged",
+			ip:   "",
+			want: "",
+		},
+		{
+			name: "IPv6 test 1",
+			ip:   "2001:DB8::21f:5bff:febf:ce22:8a2e",
+			want: "2001:db8:0:21f::",
+		},
+		{
+			name: "IPv6 test 2",
+			ip:   "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			want: "2001:db8:85a3::",
+		},
+		{
+			name: "IPv6 test 3",
+			ip:   "fe80::1ff:fe23:4567:890a",
+			want: "fe80::",
+		},
+		{
+			name: "IPv6 test 4",
+			ip:   "f:f:f:f:f:f:f:f",
+			want: "f:f:f:f::",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanonicalizeIP(tt.ip); got != tt.want {
+				t.Errorf("CanonicalizeIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -49,6 +49,7 @@ func ShouldSkipLimiter(lmt *limiter.Limiter, r *http.Request) bool {
 	// Filter by remote ip
 	// If we are unable to find remoteIP, skip limiter
 	remoteIP := libstring.RemoteIP(lmt.GetIPLookups(), lmt.GetForwardedForIndexFromBehind(), r)
+	remoteIP = libstring.CanonicalizeIP(remoteIP)
 	if remoteIP == "" {
 		return true
 	}
@@ -176,6 +177,7 @@ func ShouldSkipLimiter(lmt *limiter.Limiter, r *http.Request) bool {
 // BuildKeys generates a slice of keys to rate-limit by given limiter and request structs.
 func BuildKeys(lmt *limiter.Limiter, r *http.Request) [][]string {
 	remoteIP := libstring.RemoteIP(lmt.GetIPLookups(), lmt.GetForwardedForIndexFromBehind(), r)
+	remoteIP = libstring.CanonicalizeIP(remoteIP)
 	path := r.URL.Path
 	sliceKeys := make([][]string, 0)
 

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -40,6 +40,7 @@ func TestDefaultBuildKeys(t *testing.T) {
 	}
 
 	request.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+	expectedIP := "2601:7:1c82:4097::"
 
 	sliceKeys := BuildKeys(lmt, request)
 	if len(sliceKeys) == 0 {
@@ -48,7 +49,7 @@ func TestDefaultBuildKeys(t *testing.T) {
 
 	for _, keys := range sliceKeys {
 		expectedKeys := [][]string{
-			{request.Header.Get("X-Real-IP")},
+			{expectedIP},
 			{request.URL.Path},
 		}
 
@@ -65,7 +66,7 @@ func TestIgnoreURLBuildKeys(t *testing.T) {
 		t.Errorf("Unable to create new HTTP request. Error: %v", err)
 	}
 
-	request.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+	request.Header.Set("X-Real-IP", "172.217.0.46")
 
 	for _, keys := range BuildKeys(lmt, request) {
 		for i, keyChunk := range keys {
@@ -86,6 +87,7 @@ func TestBasicAuthBuildKeys(t *testing.T) {
 	}
 
 	request.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+	expectedIP := "2601:7:1c82:4097::"
 
 	request.SetBasicAuth("bro", "tato")
 
@@ -96,7 +98,7 @@ func TestBasicAuthBuildKeys(t *testing.T) {
 
 	for _, keys := range sliceKeys {
 		expectedKeys := [][]string{
-			{request.Header.Get("X-Real-IP")},
+			{expectedIP},
 			{request.URL.Path},
 			{"bro"},
 		}
@@ -114,7 +116,7 @@ func TestCustomHeadersBuildKeys(t *testing.T) {
 		t.Errorf("Unable to create new HTTP request. Error: %v", err)
 	}
 
-	request.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+	request.Header.Set("X-Real-IP", "172.217.0.46")
 	request.Header.Set("X-Auth-Token", "totally-top-secret")
 
 	sliceKeys := BuildKeys(lmt, request)
@@ -144,6 +146,7 @@ func TestRequestMethodBuildKeys(t *testing.T) {
 	}
 
 	request.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+	expectedIP := "2601:7:1c82:4097::"
 
 	sliceKeys := BuildKeys(lmt, request)
 	if len(sliceKeys) == 0 {
@@ -152,7 +155,7 @@ func TestRequestMethodBuildKeys(t *testing.T) {
 
 	for _, keys := range sliceKeys {
 		expectedKeys := [][]string{
-			{request.Header.Get("X-Real-IP")},
+			{expectedIP},
 			{request.URL.Path},
 			{"GET"},
 		}
@@ -170,7 +173,7 @@ func TestContextValueBuildKeys(t *testing.T) {
 		t.Errorf("Unable to create new HTTP request. Error: %v", err)
 	}
 
-	request.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+	request.Header.Set("X-Real-IP", "172.217.0.46")
 	//nolint:golint,staticcheck // limiter.SetContextValue requires string as a key, so we have to live with that
 	request = request.WithContext(context.WithValue(request.Context(), "API-access-level", "basic"))
 
@@ -202,6 +205,7 @@ func TestRequestMethodAndCustomHeadersBuildKeys(t *testing.T) {
 	}
 
 	request.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+	expectedIP := "2601:7:1c82:4097::"
 	request.Header.Set("X-Auth-Token", "totally-top-secret")
 
 	sliceKeys := BuildKeys(lmt, request)
@@ -211,7 +215,7 @@ func TestRequestMethodAndCustomHeadersBuildKeys(t *testing.T) {
 
 	for _, keys := range sliceKeys {
 		expectedKeys := [][]string{
-			{request.Header.Get("X-Real-IP")},
+			{expectedIP},
 			{request.URL.Path},
 			{"GET"},
 			{"X-Auth-Token"},
@@ -232,7 +236,7 @@ func TestRequestMethodAndBasicAuthUsersBuildKeys(t *testing.T) {
 		t.Errorf("Unable to create new HTTP request. Error: %v", err)
 	}
 
-	request.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+	request.Header.Set("X-Real-IP", "172.217.0.46")
 	request.SetBasicAuth("bro", "tato")
 
 	sliceKeys := BuildKeys(lmt, request)
@@ -264,6 +268,7 @@ func TestRequestMethodCustomHeadersAndBasicAuthUsersBuildKeys(t *testing.T) {
 	}
 
 	request.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+	expectedIP := "2601:7:1c82:4097::"
 	request.Header.Set("X-Auth-Token", "totally-top-secret")
 	request.SetBasicAuth("bro", "tato")
 
@@ -274,7 +279,7 @@ func TestRequestMethodCustomHeadersAndBasicAuthUsersBuildKeys(t *testing.T) {
 
 	for _, keys := range sliceKeys {
 		expectedKeys := [][]string{
-			{request.Header.Get("X-Real-IP")},
+			{expectedIP},
 			{request.URL.Path},
 			{"GET"},
 			{"X-Auth-Token"},
@@ -298,7 +303,7 @@ func TestRequestMethodCustomHeadersAndBasicAuthUsersAndContextValuesBuildKeys(t 
 		t.Errorf("Unable to create new HTTP request. Error: %v", err)
 	}
 
-	request.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+	request.Header.Set("X-Real-IP", "172.217.0.46")
 	request.Header.Set("X-Auth-Token", "totally-top-secret")
 	request.SetBasicAuth("bro", "tato")
 	//nolint:golint,staticcheck // limiter.SetContextValue requires string as a key, so we have to live with that
@@ -353,6 +358,9 @@ func TestLimitHandler(t *testing.T) {
 
 	ch := make(chan int)
 	go func() {
+		// Different address, same /64 prefix
+		req.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c9")
+
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
 		// Should be limited
@@ -391,7 +399,7 @@ func TestOverrideForResponseWriter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req.Header.Set("X-Real-IP", "2601:7:1c82:4097:59a0:a80b:2841:b8c8")
+	req.Header.Set("X-Real-IP", "172.217.0.46")
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)


### PR DESCRIPTION
Right now tollbooth handles IPv6 addresses the same as IPv4 -- it blocks individual addresses. But the _smallest_ assignment a home user can get is a /64 prefix (2^64 addresses), and it's common to get a /56 or even a /48 (2^72 and 2^80 addresses, respectively). (ref: [RIPE](https://www.ripe.net/publications/docs/ripe-690), [RFC 6177](https://datatracker.ietf.org/doc/html/rfc6177))

Because there's no size limit on the rate limiting cache in tollbooth, that means that a single home-user-attacker could blow up the memory of a server using tollbooth. (And size-limiting by itself is no good, because any size limit less than 2^64 means that a single attacker could just cycle IPs and never be blocked.)

Blocking /64 prefixes is also what [Cloudflare](https://support.cloudflare.com/hc/en-us/articles/115001635128-Configuring-Cloudflare-Rate-Limiting) and [Nextcloud](https://hackerone.com/reports/1154003) do. (There are [more complex possible approaches](https://serverfault.com/a/863511/476142).)

(I wrote a blog post about this IPv6 rate-limiting stuff but then decided I'd better PR fixes before publishing it. But if you want a lot more detail: https://gist.github.com/adam-p/900f0d96882e59c891825bbeb53d5589)

Notes about the changes:
* I don't love having the CanonicalizeIP function separate from RemoteIP, but it makes the separation-of-concerns cleaner, and the tests cleaner as well. 
* In the tollbooth package tests I alternated between IPv6 and IPv4 so that they both get exercised.

Note that I'm submitting a similar PR with similar code to https://github.com/go-chi/httprate