### PR TITLE
Fixes deadlock in ExecOnLimitReached

### DIFF
--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -261,9 +261,9 @@ func (l *Limiter) SetOnLimitReached(fn func(w http.ResponseWriter, r *http.Reque
 // ExecOnLimitReached is thread-safe way of executing after-rejection function when limit is reached.
 func (l *Limiter) ExecOnLimitReached(w http.ResponseWriter, r *http.Request) {
 	l.RLock()
-	defer l.RUnlock()
-
 	fn := l.onLimitReached
+	l.RUnlock()
+
 	if fn != nil {
 		fn(w, r)
 	}


### PR DESCRIPTION
This moves the the mutex unlock in `ExecOnLimitReached` so that it isn't around the function that gets executed.

Including the function in the lock may result in a deadlock if there are any method calls in the function that call `RLock` again.

For https://github.com/didip/tollbooth/issues/106