### PR TITLE
Switch Readme recommendation to use HTTPMiddleware

### DIFF
--- a/tollbooth.go
+++ b/tollbooth.go
@@ -349,7 +349,7 @@ func LimitFuncHandler(lmt *limiter.Limiter, nextFunc func(http.ResponseWriter, *
 
 // HTTPMiddleware wraps http.Handler with tollbooth limiter
 func HTTPMiddleware(lmt *limiter.Limiter) func(http.Handler) http.Handler {
-	// // set IP lookup only if not set
+	// set IP lookup only if not set
 	if lmt.GetIPLookup().Name == "" {
 		lmt.SetIPLookup(limiter.IPLookup{Name: "RemoteAddr"})
 	}


### PR DESCRIPTION
Followup on #113. I'll also update https://github.com/didip/tollbooth_chi Readme to clarify that it's not needed anymore as `tollbooth.HTTPMiddleware` could be used instead without any wrappers.