### PR TITLE
Update GitHub Action and golangci-lint to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,6 @@ jobs:
           go build -race
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,33 +1,40 @@
+version: "2"
 linters:
+  default: none
   enable:
-    - revive
-    - govet
-    - unconvert
-    - megacheck
-    - gas
-    - gocyclo
     - dupl
+    - gochecknoinits
+    - gocritic
+    - gocyclo
+    - gosec
+    - govet
+    - ineffassign
     - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - unconvert
     - unparam
     - unused
-    - typecheck
-    - ineffassign
-    - stylecheck
-    - gochecknoinits
-    - exportloopref
-    - gocritic
-    - nakedret
-    - gosimple
-    - prealloc
-  fast: false
-  disable-all: true
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - dupl
-    - text: "Errors unhandled"
-      linters:
-        - gosec
-  exclude-use-default: false
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - dupl
+        path: _test\.go
+      - linters:
+          - gosec
+        text: Errors unhandled
+    paths:
+      - internal/time/rate
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/limiter/limiter_options.go
+++ b/limiter/limiter_options.go
@@ -9,6 +9,7 @@ type ExpirableOptions struct {
 	DefaultExpirationTTL time.Duration
 
 	// How frequently expire job triggers
+	//
 	// Deprecated: not used anymore
 	ExpireJobInterval time.Duration
 }

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -197,7 +197,7 @@ func BuildKeys(lmt *limiter.Limiter, r *http.Request) [][]string {
 	remoteIP := libstring.RemoteIPFromIPLookup(lmt.GetIPLookup(), r)
 	remoteIP = libstring.CanonicalizeIP(remoteIP)
 	path := r.URL.Path
-	sliceKeys := make([][]string, 0)
+	sliceKeys := make([][]string, 0, 1)
 
 	lmtMethods := lmt.GetMethods()
 	lmtHeaders := lmt.GetHeaders()


### PR DESCRIPTION
Project currently uses golangci-lint-action@v4, which is about two years out of date. It was also bringing in an old version of golangci-lint, which couldn't lint any past go 1.24.

Updating action (v4 -> v9) and linter (v1 -> v2). Linter v2 uses a new schema. `golangci-lint migrate` was used to migrate the schema.

New linter also flagged a couple of code issues. Updating code to fix lint errors.